### PR TITLE
Sidekiq 8 compatibility

### DIFF
--- a/lib/sidekiq/debouncer/version.rb
+++ b/lib/sidekiq/debouncer/version.rb
@@ -2,6 +2,6 @@
 
 module Sidekiq
   module Debouncer
-    VERSION = "3.0.0"
+    VERSION = "3.1.0"
   end
 end

--- a/sidekiq-debouncer.gemspec
+++ b/sidekiq-debouncer.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
     "sidekiq-debouncer.gemspec"
   ]
 
-  gem.add_dependency "sidekiq", ">= 7.0", "< 8.0"
+  gem.add_dependency "sidekiq", ">= 7.0", "< 9.0"
 
   gem.add_development_dependency "rspec", "~> 3.12.0"
   gem.add_development_dependency "timecop", "~> 0.9.6"


### PR DESCRIPTION
We are blocked from upgrading to version 8 of the `sidekiq` gem by this gem. In order to make this gem compatible, I updated the `sidekiq` dependency in `sidekiq-debouncer.gemspec` to `">= 7.0", "< 9.0"`

I will submit a PR from this forked version back to the original repo. We can use this version while we wait for their approval.